### PR TITLE
New satellite fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/stratoberry/go-gpsd
+module github.com/swilcox/go-gpsd
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/swilcox/go-gpsd
+module github.com/stratoberry/go-gpsd
 
 go 1.18

--- a/gpsd.go
+++ b/gpsd.go
@@ -184,11 +184,14 @@ type ERRORReport struct {
 
 // Satellite describes a location of a GPS satellite
 type Satellite struct {
-	PRN  float64 `json:"PRN"`
-	Az   float64 `json:"az"`
-	El   float64 `json:"el"`
-	Ss   float64 `json:"ss"`
-	Used bool    `json:"used"`
+	PRN    float64 `json:"PRN"`
+	Az     float64 `json:"az"`
+	El     float64 `json:"el"`
+	Ss     float64 `json:"ss"`
+	Used   bool    `json:"used"`
+	GnssId float64 `json:"gnssid"`
+	SvId   float64 `json:"svid"`
+	Health float64 `json:"health"`
 }
 
 // Dial opens a new connection to GPSD.


### PR DESCRIPTION
This updates the satellite JSON to more closely match the gpsd current standard. The only field not added is `freqid` since that's GLONASS only. This could be added as an optional. This information is from the gpsd [documentation](https://gpsd.gitlab.io/gpsd/gpsd_json.html): 

Name | Always? | Type | Description
-- | -- | -- | --
PRN | Yes | numeric | PRN ID of the satellite.  See "PRN, GNSS id, SV id, and SIG id"
az | No | numeric | Azimuth, degrees from true north.
el | No | numeric | Elevation in degrees.
freqid | No | numeric | For GLONASS satellites only: the frequency ID of the signal. As defined by u-blox, range 0 to 13. The freqid is the frequency slot plus 7.
gnssid | No | numeric | The GNSS ID.  See "PRN, GNSS id, SV id, and SIG id"
health | No | numeric | The health of this satellite. 0 is unknown, 1 is OK, and 2 is unhealthy.
ss | No | numeric | Signal to Noise ratio in dBHz.
sigid | No | numeric | The signal ID of this signal. See "PRN, GNSS id, SV id, and SIG id" u-blox, not NMEA. See u-blox doc for details.
svid | No | numeric | The satellite ID (PRN) within its constellation. See  "<<PRNs>"
used | Yes | boolean | Used in current solution? (SBAS/WAAS/EGNOS satellites may be flagged used if the solution has corrections from them, but not all drivers make this information available.)

