### PR TITLE
Check class validity in Session.AddFilter()

### DIFF
--- a/gpsd.go
+++ b/gpsd.go
@@ -242,6 +242,7 @@ func (s *Session) SendCommand(command string) {
 
 // AddFilter attaches a function which will be called for all
 // GPSD reports with the given class. Callback functions have type Filter.
+// An error is returned if the given class is invalid.
 //
 // Example:
 //
@@ -252,8 +253,18 @@ func (s *Session) SendCommand(command string) {
 //	})
 //	done := gps.Watch()
 //	<- done
-func (s *Session) AddFilter(class string, f Filter) {
+func (s *Session) AddFilter(class string, f Filter) error {
+
+	// Check that class is a valid class string
+	switch class {
+	case "TPV", "SKY", "GST", "ATT", "VERSION", "DEVICES", "PPS", "TOFF", "ERROR":
+	default:
+		return errors.New("the provided class string is not a valid class")
+	}
+
 	s.filters[class] = append(s.filters[class], f)
+
+	return nil
 }
 
 func (s *Session) deliverReport(class string, report interface{}) {
@@ -265,7 +276,7 @@ func (s *Session) deliverReport(class string, report interface{}) {
 // Close closes the connection to GPSD
 func (s *Session) Close() error {
 	if s.socket == nil {
-		return errors.New("gpsd socket is alerady closed")
+		return errors.New("gpsd socket is already closed")
 	}
 
 	if err := s.socket.Close(); err != nil {


### PR DESCRIPTION
Hello there! I was using go-gpsd and it was quite useful, but I spent half an hour inspecting my codebase for a bug because I was getting SKY reports but no TPV reports. Turns out I mispelled TPV and my code wasn't working as expected. I think that checking the validity of class in Session.AddFilter() would be a great addition. It would also be backwards compatible, because old users just ignore the returned error, while new users can check for it. Thank you for your time, I hope my contribution will be welcome.